### PR TITLE
Fix outdated pnpm lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "vitest": "^3.2.3",
-    "@types/mdast": "^4.0.4",
-    "@types/gray-matter": "0.0.4"
+    "@types/mdast": "^4.0.4"
   }
 }


### PR DESCRIPTION
The `pnpm install --frozen-lockfile` command failed due to an `ERR_PNPM_OUTDATED_LOCKFILE` error, indicating a mismatch between `package.json` and `pnpm-lock.yaml`.

The discrepancy was caused by the presence of `@types/gray-matter` in `package.json`'s `devDependencies`. This type definition package is no longer necessary as the `gray-matter` module now includes its own bundled TypeScript types.

To resolve the issue:
*   The `@types/gray-matter` entry was removed from the `devDependencies` in `package.json`.
*   `pnpm install` was executed to regenerate `pnpm-lock.yaml`, ensuring it accurately reflects the updated `package.json` dependencies.

These changes synchronize the lockfile with the package manifest, allowing `pnpm install --frozen-lockfile` to succeed in CI environments.