### PR TITLE
feat: Add support for Gemini CLI's GEMINI.md configuration files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ ${color.bold('Usage:')}
 ${color.bold('Options:')}
   ${color.yellow('-h, --help')}       Show this help message
   ${color.yellow('-o, --output')}     Output file path (for convert command)
-  ${color.yellow('-f, --format')}     Specify format (copilot|cursor|cline|windsurf|zed|codex|aider|claude|qodo)
+  ${color.yellow('-f, --format')}     Specify format (copilot|cursor|cline|windsurf|zed|codex|aider|claude|gemini|qodo)
   ${color.yellow('-w, --overwrite')}  Overwrite existing files
   ${color.yellow('-d, --dry-run')}    Preview operations without making changes
 
@@ -97,6 +97,7 @@ async function main() {
           '.rules',
           'AGENTS.md',
           'CLAUDE.md',
+          'GEMINI.md',
           'best_practices.md'
         ]))
       } else {
@@ -179,6 +180,7 @@ async function main() {
         { path: 'AGENTS.md', format: 'OpenAI Codex' },
         { path: 'CONVENTIONS.md', format: 'Aider' },
         { path: 'CLAUDE.md', format: 'Claude Code' },
+        { path: 'GEMINI.md', format: 'Gemini CLI' },
         { path: 'best_practices.md', format: 'Qodo Merge' }
       ]
 
@@ -229,11 +231,12 @@ async function main() {
         else if (inputPath.endsWith('.rules')) format = 'zed'
         else if (inputPath.endsWith('AGENTS.md')) format = 'codex'
         else if (inputPath.endsWith('CLAUDE.md')) format = 'claude'
+        else if (inputPath.endsWith('GEMINI.md')) format = 'gemini'
         else if (inputPath.endsWith('CONVENTIONS.md')) format = 'aider'
         else if (inputPath.endsWith('best_practices.md')) format = 'qodo'
         else {
           console.error(color.error('Cannot auto-detect format'))
-          console.error(color.dim('Hint: Specify format with -f (copilot|cursor|cline|windsurf|zed|codex|aider|claude|qodo)'))
+          console.error(color.dim('Hint: Specify format with -f (copilot|cursor|cline|windsurf|zed|codex|aider|claude|gemini|qodo)'))
           process.exit(1)
         }
       }
@@ -242,7 +245,7 @@ async function main() {
       console.log(`Input: ${color.path(inputPath)}`)
 
       // Import using appropriate importer
-      const { importCopilot, importCursor, importCline, importWindsurf, importZed, importCodex, importAider, importClaudeCode, importQodo } = await import('./importers.js')
+      const { importCopilot, importCursor, importCline, importWindsurf, importZed, importCodex, importAider, importClaudeCode, importGemini, importQodo } = await import('./importers.js')
       
       let result
       switch (format) {
@@ -269,6 +272,9 @@ async function main() {
           break
         case 'claude':
           result = importClaudeCode(inputPath)
+          break
+        case 'gemini':
+          result = importGemini(inputPath)
           break
         case 'qodo':
           result = importQodo(inputPath)
@@ -322,7 +328,8 @@ function updateGitignore(repoPath: string): void {
     '.rules.local',
     'AGENTS.local.md',
     'CONVENTIONS.local.md',
-    'CLAUDE.local.md'
+    'CLAUDE.local.md',
+    'GEMINI.local.md'
   ].join('\n')
   
   if (existsSync(gitignorePath)) {

--- a/src/exporters.ts
+++ b/src/exporters.ts
@@ -258,6 +258,21 @@ export function exportToClaudeCode(rules: RuleBlock[], outputPath: string, optio
   writeFileSync(outputPath, content, 'utf-8')
 }
 
+export function exportToGemini(rules: RuleBlock[], outputPath: string, options?: ExportOptions): void {
+  // Filter out private rules unless includePrivate is true
+  const filteredRules = rules.filter(rule => !rule.metadata.private || options?.includePrivate)
+  
+  const content = filteredRules
+    .map(rule => {
+      const header = rule.metadata.description ? `# ${rule.metadata.description}\n\n` : ''
+      return header + rule.content
+    })
+    .join('\n\n')
+
+  ensureDirectoryExists(outputPath)
+  writeFileSync(outputPath, content, 'utf-8')
+}
+
 export function exportToQodo(rules: RuleBlock[], outputPath: string, options?: ExportOptions): void {
   // Filter out private rules unless includePrivate is true
   const filteredRules = rules.filter(rule => !rule.metadata.private || options?.includePrivate)
@@ -285,6 +300,7 @@ export function exportAll(rules: RuleBlock[], repoPath: string, dryRun = false, 
     exportToCodex(rules, join(repoPath, 'AGENTS.md'), options)
     exportToAider(rules, join(repoPath, 'CONVENTIONS.md'), options)
     exportToClaudeCode(rules, join(repoPath, 'CLAUDE.md'), options)
+    exportToGemini(rules, join(repoPath, 'GEMINI.md'), options)
     exportToQodo(rules, join(repoPath, 'best_practices.md'), options)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   importCodex,
   importAider,
   importClaudeCode,
+  importGemini,
   importQodo
 } from './importers.js'
 
@@ -29,6 +30,7 @@ export {
   exportToCodex,
   exportToAider,
   exportToClaudeCode,
+  exportToGemini,
   exportToQodo,
   exportAll
 } from './exporters.js'

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface RuleBlock {
 }
 
 export interface ImportResult {
-  format: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'unknown'
+  format: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'gemini' | 'unknown'
   filePath: string
   rules: RuleBlock[]
   raw?: string
@@ -33,7 +33,7 @@ export interface ImportResults {
 }
 
 export interface ExportOptions {
-  format?: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo'
+  format?: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'gemini'
   outputPath?: string
   overwrite?: boolean
   includePrivate?: boolean // Include private rules in export

--- a/test/gemini.test.ts
+++ b/test/gemini.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest'
+import { importGemini, exportToGemini } from '../src/index.js'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { RuleBlock } from '../src/types.js'
+
+describe('Gemini CLI format', () => {
+  it('should import GEMINI.md file', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'gemini-test-'))
+    const geminiPath = join(tempDir, 'GEMINI.md')
+    
+    const content = `# Project Context
+
+This project is a Python FastAPI application with SQLAlchemy.
+
+## Coding Standards
+
+- Use type hints for all function parameters and returns
+- Follow PEP 8 style guidelines
+- All functions must have docstrings
+
+## Common Commands
+
+\`\`\`bash
+uvicorn main:app --reload  # Start development server
+pytest                     # Run tests
+python -m pip install -e . # Install in development mode
+\`\`\`
+
+## Architecture Notes
+
+The app uses SQLAlchemy for ORM and Pydantic for data validation.`
+
+    writeFileSync(geminiPath, content, 'utf8')
+
+    try {
+      const result = importGemini(geminiPath)
+
+      expect(result.format).toBe('gemini')
+      expect(result.filePath).toBe(geminiPath)
+      expect(result.rules).toHaveLength(1)
+      expect(result.rules[0].metadata.id).toBe('gemini-instructions')
+      expect(result.rules[0].metadata.alwaysApply).toBe(true)
+      expect(result.rules[0].content).toContain('Project Context')
+      expect(result.rules[0].content).toContain('uvicorn main:app')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should export to GEMINI.md format', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'gemini-export-'))
+    const geminiPath = join(tempDir, 'GEMINI.md')
+
+    const rules: RuleBlock[] = [
+      {
+        metadata: {
+          id: 'project-setup',
+          description: 'Project Setup Instructions',
+          alwaysApply: true
+        },
+        content: `## Environment Setup
+
+Use Python 3.11+ and Poetry for dependency management.
+
+### Required Tools
+- Poetry
+- Python 3.11+
+- pytest`
+      },
+      {
+        metadata: {
+          id: 'code-style',
+          description: 'Code Style Guidelines'
+        },
+        content: `## Formatting
+
+- 4 space indentation
+- Double quotes for strings
+- Type hints required`
+      }
+    ]
+
+    try {
+      exportToGemini(rules, geminiPath)
+
+      const exported = readFileSync(geminiPath, 'utf8')
+      
+      // Should include headers from descriptions
+      expect(exported).toContain('# Project Setup Instructions')
+      expect(exported).toContain('# Code Style Guidelines')
+      
+      // Should include content
+      expect(exported).toContain('Use Python 3.11+ and Poetry')
+      expect(exported).toContain('4 space indentation')
+      
+      // Should separate rules with double newlines
+      expect(exported.split('\n\n').length).toBeGreaterThan(2)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should handle rules without descriptions', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'gemini-nodesc-'))
+    const geminiPath = join(tempDir, 'GEMINI.md')
+
+    const rules: RuleBlock[] = [
+      {
+        metadata: {
+          id: 'basic-rule',
+          alwaysApply: true
+        },
+        content: 'Always use type hints'
+      }
+    ]
+
+    try {
+      exportToGemini(rules, geminiPath)
+
+      const exported = readFileSync(geminiPath, 'utf8')
+      
+      // Should not have a header if no description
+      expect(exported).not.toContain('#')
+      expect(exported.trim()).toBe('Always use type hints')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should preserve content formatting during import/export', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'gemini-preserve-'))
+    const geminiPath = join(tempDir, 'GEMINI.md')
+    
+    const originalContent = `# Development Guidelines
+
+## Code Structure
+
+\`\`\`
+src/
+  models/
+  routes/
+  schemas/
+\`\`\`
+
+### Important Notes
+
+1. Always validate request data
+2. Handle exceptions gracefully
+3. Write tests for all endpoints
+
+> Remember: Explicit is better than implicit`
+
+    writeFileSync(geminiPath, originalContent, 'utf8')
+
+    try {
+      // Import
+      const imported = importGemini(geminiPath)
+      
+      // Export to a different location
+      const exportPath = join(tempDir, 'GEMINI-exported.md')
+      exportToGemini(imported.rules, exportPath)
+      
+      const exported = readFileSync(exportPath, 'utf8')
+      
+      // The content should be preserved (with added header)
+      expect(exported).toContain('# Gemini CLI context and instructions')
+      expect(exported).toContain('Always validate request data')
+      expect(exported).toContain('Explicit is better than implicit')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should handle private GEMINI.local.md files', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'gemini-private-'))
+    const geminiLocalPath = join(tempDir, 'GEMINI.local.md')
+    
+    const content = `# Private Development Settings
+
+## API Keys
+
+Use environment variables for sensitive data.
+
+## Local Configuration
+
+Development server runs on port 8000.`
+
+    writeFileSync(geminiLocalPath, content, 'utf8')
+
+    try {
+      const result = importGemini(geminiLocalPath)
+
+      expect(result.format).toBe('gemini')
+      expect(result.filePath).toBe(geminiLocalPath)
+      expect(result.rules).toHaveLength(1)
+      expect(result.rules[0].metadata.private).toBe(true)
+      expect(result.rules[0].content).toContain('API Keys')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
Asked Claude to work on this 😄 
Fixes #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing and exporting the "gemini" markdown format, including handling of GEMINI.md and GEMINI.local.md files.
  * "Gemini" is now available as a selectable format in the CLI tool.

* **Bug Fixes**
  * Improved file detection and handling for Gemini CLI instruction files.

* **Tests**
  * Introduced comprehensive tests for Gemini format import and export functionality, including private file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->