### PR TITLE
feat: add --formats and --no-gitignore flags for non-interactive export

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,37 +44,66 @@ pnpm add -g dotagent
 
 ```bash
 # Import from current directory (creates .agent/ directory)
-agentconfig import .
+dotagent import .
 
 # Import from specific path
-agentconfig import /path/to/repo
+dotagent import /path/to/repo
 
 # Preview without making changes
-agentconfig import . --dry-run
+dotagent import . --dry-run
 ```
 
-### Export `.agent/` directory to all formats
+### Export `.agent/` directory to formats
 
 ```bash
-# Export from current directory's .agent/
-agentconfig export .
+# Interactive export (shows menu to select format)
+dotagent export
 
-# Export to specific directory
-agentconfig export . -o /path/to/repo
+# Export to specific format (non-interactive)
+dotagent export --format copilot
+
+# Export to multiple formats (non-interactive)
+dotagent export --formats copilot,claude,cursor
+
+# Export all formats at once
+dotagent export --formats all
+
+# Export from specific directory
+dotagent export /path/to/repo --format copilot
 
 # Include private rules in export
-agentconfig export --include-private
+dotagent export --include-private --format copilot
+
+# Skip gitignore prompt (useful for CI/CD)
+dotagent export --format copilot --no-gitignore
+
+# Preview without making changes
+dotagent export --dry-run
 ```
 
 ### Convert a specific file
 
 ```bash
 # Auto-detect format
-agentconfig convert .github/copilot-instructions.md
+dotagent convert .github/copilot-instructions.md
 
 # Specify format explicitly
-agentconfig convert my-rules.md -f cursor
+dotagent convert my-rules.md -f cursor
 ```
+
+### CLI Flags Reference
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--help` | `-h` | Show help message |
+| `--format` | `-f` | Export to single format (copilot\|cursor\|cline\|windsurf\|zed\|codex\|aider\|claude\|gemini\|qodo) |
+| `--formats` | | Export to multiple formats (comma-separated list) |
+| `--output` | `-o` | Output directory path |
+| `--overwrite` | `-w` | Overwrite existing files |
+| `--dry-run` | `-d` | Preview operations without making changes |
+| `--include-private` | | Include private rules in export |
+| `--skip-private` | | Skip private rules during import |
+| `--no-gitignore` | | Skip gitignore update prompt |
 
 ## Unified Format
 


### PR DESCRIPTION
## Summary
- Adds `--formats` flag for comma-separated format list support  
- Adds `--no-gitignore` flag to skip gitignore prompt
- Enables non-interactive export for CI/CD automation
- Maintains full backward compatibility

## Changes Made
- ✅ Added `--formats` parameter for multiple format export
- ✅ Added `--no-gitignore` flag to skip interactive gitignore prompt
- ✅ Format validation with helpful error messages
- ✅ Updated README with comprehensive documentation
- ✅ Fixed README inconsistencies (`agentconfig` → `dotagent`)

## Usage Examples
```bash
# Export to specific format (non-interactive)
dotagent export --format copilot --no-gitignore

# Export to multiple formats  
dotagent export --formats copilot,claude,cursor --no-gitignore

# Export all formats
dotagent export --formats all --no-gitignore

# Interactive mode still works (backward compatible)
dotagent export
```

## Test plan
- [x] Tested single format export with `--format`
- [x] Tested multiple format export with `--formats`
- [x] Tested format validation with invalid formats
- [x] Tested `--no-gitignore` flag functionality
- [x] Verified backward compatibility with interactive mode
- [x] Updated help text and README documentation

## Fixes
Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting to multiple formats at once using a new CLI option.
  * Introduced a flag to skip the gitignore prompt during export.

* **Documentation**
  * Updated CLI usage instructions and examples to reflect new command prefixes and options.
  * Expanded export section with detailed usage scenarios and added a comprehensive CLI flags reference table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->