### PR TITLE
Add support for Roo Code and JetBrains Junie

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,22 @@ Multi-file AI agent configuration manager with .agent directory support. Maintai
 
 ## Supported Formats
 
-| Tool/IDE | Rule File | Format |
-|----------|-----------|---------|
-| Agent (dotagent) | `.agent/**/*.md` | Markdown with YAML frontmatter |
-| Claude Code | `CLAUDE.md` | Plain Markdown |
-| VS Code (Copilot) | `.github/copilot-instructions.md` | Plain Markdown |
-| Cursor | `.cursor/**/*.mdc`, `.cursor/**/*.md` | Markdown with YAML frontmatter |
-| Cline | `.clinerules` or `.clinerules/*.md` | Plain Markdown |
-| Windsurf | `.windsurfrules` | Plain Markdown |
-| Zed | `.rules` | Plain Markdown |
-| OpenAI Codex | `AGENTS.md` | Plain Markdown |
-| Aider | `CONVENTIONS.md` | Plain Markdown |
-| Gemini | `GEMINI.md` | Plain Markdown |
-| Qodo | `best_practices.md` | Plain Markdown |
-| Amazon Q Developer | `.amazonq/rules/*.md` | Plain Markdown |
+| Tool/IDE           | Rule File                             | Format                         | Slug     |
+| ------------------ | ------------------------------------- | ------------------------------ | -------- |
+| Agent (dotagent)   | `.agent/**/*.md`                      | Markdown with YAML frontmatter | agent    |
+| Claude Code        | `CLAUDE.md`                           | Plain Markdown                 | claude   |
+| VS Code (Copilot)  | `.github/copilot-instructions.md`     | Plain Markdown                 | copilot  |
+| Cursor             | `.cursor/**/*.mdc`, `.cursor/**/*.md` | Markdown with YAML frontmatter | cursor   |
+| Cline              | `.clinerules` or `.clinerules/*.md`   | Plain Markdown                 | cline    |
+| Windsurf           | `.windsurfrules`                      | Plain Markdown                 | windsurf |
+| Zed                | `.rules`                              | Plain Markdown                 | zed      |
+| OpenAI Codex       | `AGENTS.md`                           | Plain Markdown                 | codex    |
+| Aider              | `CONVENTIONS.md`                      | Plain Markdown                 | aider    |
+| Gemini             | `GEMINI.md`                           | Plain Markdown                 | gemini   |
+| Qodo               | `best_practices.md`                   | Plain Markdown                 | qodo     |
+| Amazon Q Developer | `.amazonq/rules/*.md`                 | Plain Markdown                 | amazonq  |
+| JetBrains Junie    | `.junie/guidelines.md`                | Plain Markdown                 | junie    |
+| Roo Code           | `.roo/rules/*.md`                     | Markdown with YAML frontmatter | roo      |
 
 ## Installation
 
@@ -75,6 +77,9 @@ dotagent export /path/to/repo --format copilot
 # Include private rules in export
 dotagent export --include-private --format copilot
 
+# Auto-update gitignore (skip prompt)
+dotagent export --format copilot --gitignore
+
 # Skip gitignore prompt (useful for CI/CD)
 dotagent export --format copilot --no-gitignore
 
@@ -97,13 +102,14 @@ dotagent convert my-rules.md -f cursor
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--help` | `-h` | Show help message |
-| `--format` | `-f` | Export to single format (copilot\|cursor\|cline\|windsurf\|zed\|codex\|aider\|claude\|gemini\|qodo) |
+| `--format`          | `-f`  | Export to single format (copilot\|cursor\|cline\|windsurf\|zed\|codex\|aider\|claude\|gemini\|qodo\|junie\|roo) |
 | `--formats` | | Export to multiple formats (comma-separated list) |
 | `--output` | `-o` | Output directory path |
 | `--overwrite` | `-w` | Overwrite existing files |
 | `--dry-run` | `-d` | Preview operations without making changes |
 | `--include-private` | | Include private rules in export |
 | `--skip-private` | | Skip private rules during import |
+| `--gitignore` | | Auto-update gitignore (skip prompt) |
 | `--no-gitignore` | | Skip gitignore update prompt |
 
 ## Unified Format
@@ -204,15 +210,17 @@ Confidential requirements
 
 ### Private Rules in Other Formats
 
-| Format | Public File | Private File |
-|--------|-------------|---------------|
-| Copilot | `.github/copilot-instructions.md` | `.github/copilot-instructions.local.md` |
-| Cursor | `.cursor/rules/*.mdc` | `.cursor/rules/*.local.mdc` |
-| Cline | `.clinerules` | `.clinerules.local` |
-| Windsurf | `.windsurfrules` | `.windsurfrules.local` |
-| Zed | `.rules` | `.rules.local` |
-| Claude | `CLAUDE.md` | `CLAUDE.local.md` |
-| Gemini | `GEMINI.md` | `GEMINI.local.md` |
+| Format   | Public File                       | Private File                            |
+| -------- | --------------------------------- | --------------------------------------- |
+| Copilot  | `.github/copilot-instructions.md` | `.github/copilot-instructions.local.md` |
+| Cursor   | `.cursor/rules/*.mdc`             | `.cursor/rules/*.local.mdc`             |
+| Cline    | `.clinerules`                     | `.clinerules.local`                     |
+| Windsurf | `.windsurfrules`                  | `.windsurfrules.local`                  |
+| Zed      | `.rules`                          | `.rules.local`                          |
+| Claude   | `CLAUDE.md`                       | `CLAUDE.local.md`                       |
+| Gemini   | `GEMINI.md`                       | `GEMINI.local.md`                       |
+| Junie    | `.junie/guidelines.md`            | `.junie/guidelines.local.md`            |
+| Roo Code | `.roo/rules/*.md`                | `.roo/rules/*.local.md`               |
 
 ### CLI Options
 
@@ -243,6 +251,8 @@ AGENTS.local.md
 CONVENTIONS.local.md
 CLAUDE.local.md
 GEMINI.local.md
+.junie/guidelines.local.md
+.roo/rules/*.local.md
 ```
 
 ## Programmatic Usage
@@ -308,6 +318,8 @@ interface RuleMetadata {
 - `importGemini(filePath: string): ImportResult` - Import Gemini CLI format
 - `importQodo(filePath: string): ImportResult` - Import Qodo best practices
 - `importAmazonQ(rulesDir: string): ImportResult` - Import Amazon Q Developer rules
+- `importJunie(filePath: string): ImportResult` - Import JetBrains Junie guidelines
+- `importRoo(rulesDir: string): ImportResult` - Import Roo Code rules
 
 ### Export Functions
 
@@ -322,6 +334,8 @@ interface RuleMetadata {
 - `exportToAmazonQ(rules: RuleBlock[], outputDir: string): void`
 - `exportToGemini(rules: RuleBlock[], outputPath: string): void`
 - `exportToQodo(rules: RuleBlock[], outputPath: string): void`
+- `exportToJunie(rules: RuleBlock[], outputPath: string): void`
+- `exportToRoo(rules: RuleBlock[], outputDir: string): void`
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,9 @@ export {
   importClaudeCode,
   importGemini,
   importQodo,
-  importAmazonQ
+  importAmazonQ,
+  importRoo,
+  importJunie
 } from './importers.js'
 
 export {
@@ -34,6 +36,8 @@ export {
   exportToGemini,
   exportToQodo,
   exportToAmazonQ,
+  exportToRoo,
+  exportToJunie,
   exportAll
 } from './exporters.js'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface RuleBlock {
 }
 
 export interface ImportResult {
-  format: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'gemini' | 'amazonq' | 'unknown'
+  format: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'gemini' | 'amazonq' | 'roo' | 'junie' | 'unknown'
   filePath: string
   rules: RuleBlock[]
   raw?: string
@@ -33,7 +33,7 @@ export interface ImportResults {
 }
 
 export interface ExportOptions {
-  format?: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'gemini' | 'amazonq'
+  format?: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'gemini' | 'amazonq' | 'roo' | 'junie'
   outputPath?: string
   overwrite?: boolean
   includePrivate?: boolean // Include private rules in export

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,6 +1,11 @@
 import { select as inquirerSelect, confirm as inquirerConfirm } from '@inquirer/prompts'
 
 export async function confirm(question: string, defaultValue = false): Promise<boolean> {
+  // Check if we're in a non-interactive environment
+  if (!process.stdin.isTTY || process.env.NODE_ENV === 'test') {
+    return defaultValue
+  }
+  
   return await inquirerConfirm({
     message: question,
     default: defaultValue

--- a/temp-test/.agent/test.md
+++ b/temp-test/.agent/test.md
@@ -1,0 +1,1 @@
+"# Test rule"  

--- a/temp-test/.github/copilot-instructions.md
+++ b/temp-test/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+
+
+---
+
+## Context-Specific Rules

--- a/test/gitignore-flag.test.ts
+++ b/test/gitignore-flag.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+
+describe('Gitignore flag functionality', () => {
+  let tempDir: string
+  let agentDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'gitignore-flag-test-'))
+    agentDir = join(tempDir, '.agent')
+    mkdirSync(agentDir, { recursive: true })
+    
+    // Create a simple agent rule file
+    writeFileSync(join(agentDir, 'test-rule.md'), `---
+id: test-rule
+title: Test Rule
+---
+
+# Test Rule
+
+This is a test rule.`)
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function runDotAgentExport(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+    const cliPath = join(process.cwd(), 'dist', 'cli.js')
+    const cmd = `node ${cliPath} export ${args.join(' ')}`
+    
+    try {
+      const result = execSync(cmd, { 
+        cwd: tempDir,
+        encoding: 'utf-8',
+        env: { ...process.env, NODE_ENV: 'test' }
+      })
+      return { stdout: result, stderr: '', exitCode: 0 }
+    } catch (error: any) {
+      return { 
+        stdout: error.stdout || '', 
+        stderr: error.stderr || '', 
+        exitCode: error.status || 1 
+      }
+    }
+  }
+
+  it('should auto-update gitignore when --gitignore flag is used', () => {
+    const result = runDotAgentExport(['--format', 'copilot', '--gitignore'])
+    
+    expect(result.exitCode).toBe(0)
+    
+    // Check that gitignore was updated automatically
+    const gitignorePath = join(tempDir, '.gitignore')
+    expect(existsSync(gitignorePath)).toBe(true)
+    
+    const gitignoreContent = readFileSync(gitignorePath, 'utf-8')
+    expect(gitignoreContent).toContain('.github/copilot-instructions.md')
+  })
+
+  it('should skip gitignore prompt with --no-gitignore flag', () => {
+    const result = runDotAgentExport(['--format', 'copilot', '--no-gitignore'])
+    
+    expect(result.exitCode).toBe(0)
+    
+    // Check that gitignore was NOT updated
+    const gitignorePath = join(tempDir, '.gitignore')
+    // The file might exist from previous test runs, but shouldn't contain the new patterns
+    if (existsSync(gitignorePath)) {
+      const gitignoreContent = readFileSync(gitignorePath, 'utf-8')
+      expect(gitignoreContent).not.toContain('.github/copilot-instructions.md')
+    }
+  })
+
+  it('should handle --gitignore and --no-gitignore flags being mutually exclusive', () => {
+    const result = runDotAgentExport(['--format', 'copilot', '--gitignore', '--no-gitignore'])
+    
+    // Should fail or handle gracefully when both flags are used
+    expect(result.exitCode).not.toBe(0)
+  })
+
+  it('should prompt for gitignore when neither flag is specified', () => {
+    // This test would normally require mocking the prompt
+    // For now, we'll just verify the export works without flags
+    const result = runDotAgentExport(['--format', 'copilot'])
+    
+    expect(result.exitCode).toBe(0)
+    // The actual prompt behavior would be tested in integration tests
+  })
+})

--- a/test/integration/roo.test.ts
+++ b/test/integration/roo.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { importAll, exportToRoo } from '../../src/index.js'
+import { parse } from 'path'
+import type { RuleBlock } from '../../src/types.js'
+
+describe('Roo Code Integration Tests', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'dotagent-roo-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('imports .roo/rules/*.md files with frontmatter and private rules', async () => {
+    // Create .roo/rules directory structure
+    const rulesDir = join(tempDir, '.roo', 'rules')
+    const nestedDir = join(rulesDir, 'nested')
+    
+    // Public rule with frontmatter
+    writeFileSync(join(rulesDir, 'public-rule.md'), `---
+id: public-rule
+alwaysApply: true
+description: Public coding standard
+---
+# Public Rule Content
+Always use TypeScript strict mode.`)
+
+    // Private rule by filename
+    writeFileSync(join(rulesDir, 'private.local.md'), `---
+id: private-rule
+description: Private preference
+---
+# Private Rule Content
+Prefer tabs over spaces.`)
+
+    // Nested rule with frontmatter
+    writeFileSync(join(nestedDir, '001-nested.md'), `---
+id: nested/rule
+scope: src/nested/**
+priority: high
+---
+# Nested Rule Content
+Follow nested patterns.`)
+
+    // Rule with explicit private: true
+    writeFileSync(join(rulesDir, 'explicit-private.md'), `---
+id: explicit-private
+private: true
+---
+# Explicit Private Content
+Sensitive information.`)
+
+    const { results, errors } = await importAll(tempDir)
+
+    expect(errors).toHaveLength(0)
+
+    const rooResult = results.find(r => r.format === 'roo')
+    expect(rooResult).toBeDefined()
+    expect(rooResult!.rules).toHaveLength(4)
+
+    // Check public rule
+    const publicRule = rooResult!.rules.find(r => r.metadata.id === 'public-rule')
+    expect(publicRule).toBeDefined()
+    expect(publicRule!.metadata.alwaysApply).toBe(true)
+    expect(publicRule!.metadata.private).toBeUndefined()
+    expect(publicRule!.content).toContain('Always use TypeScript strict mode')
+
+    // Check private by filename
+    const privateByFile = rooResult!.rules.find(r => r.metadata.id === 'private-rule')
+    expect(privateByFile).toBeDefined()
+    expect(privateByFile!.metadata.private).toBe(true)
+
+    // Check nested
+    const nestedRule = rooResult!.rules.find(r => r.metadata.id === 'nested/rule')
+    expect(nestedRule).toBeDefined()
+    expect(nestedRule!.metadata.scope).toBe('src/nested/**')
+
+    // Check explicit private
+    const explicitPrivate = rooResult!.rules.find(r => r.metadata.id === 'explicit-private')
+    expect(explicitPrivate).toBeDefined()
+    expect(explicitPrivate!.metadata.private).toBe(true)
+  })
+
+  it('exports rules to .roo/rules preserving frontmatter and structure', () => {
+    const rules: RuleBlock[] = [
+      {
+        metadata: {
+          id: 'exported-public',
+          alwaysApply: true,
+          description: 'Exported public rule'
+        },
+        content: '# Exported Public Content\nFollow best practices.'
+      },
+      {
+        metadata: {
+          id: 'private/exported',
+          private: true,
+          scope: 'private/**'
+        },
+        content: '# Private Exported Content\nInternal only.'
+      },
+      {
+        metadata: {
+          id: 'nested/exported',
+          priority: 'high'
+        },
+        content: '# Nested Exported Content\nHigh priority rules.'
+      }
+    ]
+
+    exportToRoo(rules, tempDir)
+
+    const outputRulesDir = join(tempDir, '.roo', 'rules')
+    expect(readdirSync(outputRulesDir)).toContain('exported-public.md')
+
+    // Check public file
+    const publicContent = readFileSync(join(outputRulesDir, 'exported-public.md'), 'utf-8')
+    expect(publicContent).toMatch(/^---\n.*alwaysApply: true\n.*description: Exported public rule\n---\n\n# Exported Public Content/)
+    expect(publicContent).toContain('Follow best practices.')
+
+    // Check nested private
+    const privateDir = join(outputRulesDir, 'private')
+    expect(readdirSync(privateDir)).toContain('exported.md')
+    const privateContent = readFileSync(join(privateDir, 'exported.md'), 'utf-8')
+    expect(privateContent).toMatch(/private: true/)
+    expect(privateContent).toContain('Internal only.')
+
+    // Check nested public
+    const nestedDir = join(outputRulesDir, 'nested')
+    expect(readdirSync(nestedDir)).toContain('exported.md')
+    const nestedContent = readFileSync(join(nestedDir, 'exported.md'), 'utf-8')
+    expect(nestedContent).toMatch(/priority: high/)
+    expect(nestedContent).toContain('High priority rules.')
+  })
+
+  it('roundtrip: import from .roo/rules and export back preserves metadata', async () => {
+    // Setup input .roo/rules
+    const inputRulesDir = join(tempDir, '.roo', 'rules')
+    writeFileSync(join(inputRulesDir, 'roundtrip.md'), `---
+id: roundtrip-test
+alwaysApply: false
+scope: ['src/**', 'test/**']
+description: Roundtrip test rule
+priority: medium
+---
+# Roundtrip Content
+This should be preserved after import/export.`)
+
+    // Import
+    const { results } = await importAll(tempDir)
+    const rooResult = results.find(r => r.format === 'roo')
+    expect(rooResult!.rules).toHaveLength(1)
+
+    const importedRule = rooResult!.rules[0]
+    expect(importedRule.metadata.id).toBe('roundtrip-test')
+    expect(importedRule.metadata.alwaysApply).toBe(false)
+    expect(importedRule.metadata.scope).toEqual(['src/**', 'test/**'])
+    expect(importedRule.metadata.description).toBe('Roundtrip test rule')
+    expect(importedRule.metadata.priority).toBe('medium')
+
+    // Export back to new location
+    const outputDir = join(tempDir, 'output')
+    exportToRoo([importedRule], outputDir)
+
+    const outputFile = join(outputDir, '.roo', 'rules', 'roundtrip-test.md')
+    const exportedContent = readFileSync(outputFile, 'utf-8')
+
+    // Verify frontmatter preserved
+    expect(exportedContent).toMatch(/^---\n.*alwaysApply: false\n.*scope:\n  - src\/\*\*/)
+    expect(exportedContent).toMatch(/description: Roundtrip test rule/)
+    expect(exportedContent).toMatch(/priority: medium/)
+    expect(exportedContent).toContain('# Roundtrip Content')
+    expect(exportedContent).toContain('This should be preserved after import/export.')
+  })
+
+  it('CLI export to roo format creates correct structure', async () => {
+    // Note: This is a smoke test; full CLI integration might require spawning process
+    // For now, test the underlying export function used by CLI
+
+    const rules: RuleBlock[] = [
+      {
+        metadata: { id: 'cli-test', alwaysApply: true },
+        content: '# CLI Test Content'
+      }
+    ]
+
+    // Simulate CLI output dir
+    const cliOutputDir = join(tempDir, 'cli-output')
+    exportToRoo(rules, cliOutputDir)
+
+    const rooDir = join(cliOutputDir, '.roo', 'rules')
+    expect(readdirSync(rooDir)).toContain('cli-test.md')
+
+    const content = readFileSync(join(rooDir, 'cli-test.md'), 'utf-8')
+    expect(content).toMatch(/^---\n.*alwaysApply: true\n---\n\n# CLI Test Content/)
+  })
+
+  it('handles private rules correctly in export (excludes by default)', () => {
+    const rules: RuleBlock[] = [
+      {
+        metadata: { id: 'public', alwaysApply: true },
+        content: '# Public'
+      },
+      {
+        metadata: { id: 'private', private: true },
+        content: '# Private'
+      }
+    ]
+
+    exportToRoo(rules, tempDir)
+
+    const rulesDir = join(tempDir, '.roo', 'rules')
+    expect(readdirSync(rulesDir)).toContain('public.md')
+    expect(readdirSync(rulesDir)).not.toContain('private.md')
+
+    // With includePrivate
+    const outputDir2 = join(tempDir, 'with-private')
+    exportToRoo(rules, outputDir2, { includePrivate: true })
+
+    const rulesDir2 = join(outputDir2, '.roo', 'rules')
+    expect(readdirSync(rulesDir2)).toContain('public.md')
+    expect(readdirSync(rulesDir2)).toContain('private.md')
+
+    const privateContent = readFileSync(join(rulesDir2, 'private.md'), 'utf-8')
+    expect(privateContent).toMatch(/private: true/)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added import/export support for Roo and Junie formats with public API and structured Junie/Roo outputs; private rules excluded by default with opt-in.

- CLI
  - Roo/Junie added to format options, auto-detection, help, export/convert flows; new --gitignore / --no-gitignore flags (mutually exclusive) to auto-update .gitignore.

- Documentation
  - README and docs updated for new formats and flags.

- Tests
  - Integration tests for Roo and gitignore behavior added.

- Chores
  - Non-interactive prompt now returns defaults in non-TTY/test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->